### PR TITLE
Chore/update

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,6 +4,7 @@ if (projectId) {
 
   require('@snyk/nodejs-runtime-agent')({
     projectId,
+    beaconIntervalMs: 10000,
   });
 
   console.log('Agent loaded successfully, your application is monitored.');

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,11 +32,11 @@
       }
     },
     "@snyk/nodejs-runtime-agent": {
-      "version": "1.38.0",
-      "resolved": "https://registry.npmjs.org/@snyk/nodejs-runtime-agent/-/nodejs-runtime-agent-1.38.0.tgz",
-      "integrity": "sha512-SCbnq7LS/sMYd3hb0fFsb1ZgSO3jNOdJoLFZAaHZW7hzQWCCeLqkOwQwifdTBFEKr573FPqf//bONfs0a0Y/TA==",
+      "version": "1.42.1",
+      "resolved": "https://registry.npmjs.org/@snyk/nodejs-runtime-agent/-/nodejs-runtime-agent-1.42.1.tgz",
+      "integrity": "sha512-hjxuI/LqbX6t3xcPtcz7I/29E83iC7wWD8xPpIrEC8NSTTy9GKiVTmHrtVsIoLSz3cB+Emv6is54aVuyUjsYzA==",
       "requires": {
-        "acorn": "^5.7.1",
+        "acorn": "5.7.1",
         "debug": "^4.0.1",
         "needle": "^2.2.1",
         "semver": "^5.5.1",
@@ -44,9 +44,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "5.7.3",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-          "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw=="
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.1.tgz",
+          "integrity": "sha512-d+nbxBUGKg7Arpsvbnlq61mc12ek3EY8EQldM3GPAhWJ1UVxC6TDGbIvUMNU6obBX3i1+ptCIzV4vq0gFPEGVQ=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "eslint": "^5.12.1"
   },
   "dependencies": {
-    "@snyk/nodejs-runtime-agent": "^1.38.0",
+    "@snyk/nodejs-runtime-agent": "^1.42.1",
     "debug": "^4.1.1",
     "st": "^0.1.0",
     "uuid-validate": "0.0.3"


### PR DESCRIPTION
- bumping the nodejs-runtime-agent's version
- shorter beacon internal should make demoes smoother by default